### PR TITLE
Remove httpinfo and bind txtinfo to localhost 

### DIFF
--- a/default-files/etc/config/olsrd
+++ b/default-files/etc/config/olsrd
@@ -15,11 +15,6 @@ config 'LoadPlugin'
   option 'library' 'olsrd_secure.so.0.6'
 
 config 'LoadPlugin'
-  option 'library' 'olsrd_httpinfo.so.0.1'
-  option 'port' '1978'
-  list 'Net' '0.0.0.0 0.0.0.0'
-
-config 'LoadPlugin'
   option 'library' 'olsrd_nameservice.so.0.3'
   #option 'resolv_file' '/tmp/resolv.conf.auto'
   option 'sighup_pid_file' '/var/run/dnsmasq.pid'
@@ -33,4 +28,4 @@ config 'LoadPlugin'
 
 config 'LoadPlugin'
   option 'library' 'olsrd_txtinfo.so.0.1'
-  option 'accept' '0.0.0.0'
+  option 'accept' '127.0.0.1'


### PR DESCRIPTION
1. Remove httpinfo from the default olsrd config.
2. Make sure that txtinfo listens to connections
   from localhost only.
