### PR TITLE
Remove httpinfo and only listen locally

### DIFF
--- a/default-files/etc/config/olsrd
+++ b/default-files/etc/config/olsrd
@@ -12,11 +12,6 @@ config LoadPlugin
 
 config LoadPlugin
 	option library 'olsrd_dyn_gw.so.0.5'
-	
-config LoadPlugin
-	option library 'olsrd_httpinfo.so.0.1'
-	option port '1978'
-	list Net '0.0.0.0 0.0.0.0'
 
 config LoadPlugin
 	option library 'olsrd_nameservice.so.0.3'
@@ -26,7 +21,7 @@ config LoadPlugin
 
 config LoadPlugin
 	option library 'olsrd_txtinfo.so.0.1'
-	option accept '0.0.0.0'
+	option accept '127.0.0.1'
 
 config LoadPlugin 
 	option library 'olsrd_dnssd.so.0.1.2'
@@ -39,6 +34,6 @@ config LoadPlugin
 
 config LoadPlugin
 	option library 'olsrd_jsoninfo.so.0.0'
-	option accept '0.0.0.0'
+	option accept '127.0.0.1'
 	option 'UUIDFile' '/etc/olsrd.d/olsrd.uuid'
 


### PR DESCRIPTION
1. Remove httpinfo from the default olsrd config.
2. Make txtinfo and jsoninfo only respond to
   connections from localhost.
