### PR TITLE
added firewall exception for port 80 traffic from wan zone

### DIFF
--- a/default-files/etc/config/firewall
+++ b/default-files/etc/config/firewall
@@ -171,6 +171,12 @@ config rule
 	option proto 'tcp'
 
 config rule
+        option src 'wan'
+        option dest_port '80'
+        option target 'ACCEPT'
+        option proto 'tcp'
+
+config rule
 	option src 'ap'
 	option dest_port '80'
 	option target 'ACCEPT'


### PR DESCRIPTION
https://code.commotionwireless.net/issues/557

Blocking port 80 connections from WAN zone makes it difficult to administer a network where nodes are plugged into a LAN that also has a gateway.

Since ssh connections from the WAN zone are allowed by default, it is probably no less secure to allow http connections from the WAN zone.
