### PR TITLE
https://code.commotionwireless.net/issues/556

### DIFF
--- a/default-files/etc/nodogsplash/nodogsplash.conf
+++ b/default-files/etc/nodogsplash/nodogsplash.conf
@@ -5,8 +5,9 @@ FirewallRule allow all
 }
 
 FirewallRuleSet preauthenticated-users {
-FirewallRule allow tcp port 53                                        
+FirewallRule allow tcp port 53
 FirewallRule allow udp port 53
+FirewallRule allow tcp port 443
 FirewallRule allow to 101.0.0.0/8
 FirewallRule allow to 102.0.0.0/8
 FirewallRule allow to 103.0.0.0/8


### PR DESCRIPTION
Commotion-splash should not block port 443 traffic for unauthenticated users, in case their browser's homepage is HTTPS. Since Nodogsplash does not have the ability to do SSL, I would suggest port 443 traffic should be allowed for unauthenticated users.
