### PR TITLE
Olsrd's jsoninfo plugin

### DIFF
--- a/default-files/etc/config/olsrd
+++ b/default-files/etc/config/olsrd
@@ -19,11 +19,6 @@ config LoadPlugin
 	option 'hosts_file' '/var/run/hosts_olsr'
 	option 'suffix' '.mesh.local'
 
-config LoadPlugin
-	option library 'olsrd_txtinfo.so.0.1'
-#Set to accept local connections
-    option accept '127.0.0.1'
-
 config LoadPlugin 
 	option library 'olsrd_dnssd.so.0.1.2'
 	option 'P2pdTtl' '5'
@@ -32,6 +27,12 @@ config LoadPlugin
 	option 'ServiceFileDir' '/etc/avahi/services'
 	option 'Domain' 'mesh.local'
 	option 'ServiceUpdateInterval' '300'
+
+# OLSRD TXTINFO
+config LoadPlugin
+    option library 'olsrd_txtinfo.so.0.1'
+#Set to accept local connections
+    option accept '127.0.0.1'
 
 # OLSRD JSON INFO
 # pulls some info from txtinfo plugin as well 
@@ -43,3 +44,4 @@ config LoadPlugin
 #Hardcoding the port used
     option port 9090
 	option 'UUIDFile' '/etc/olsrd.d/olsrd.uuid'
+


### PR DESCRIPTION
In order to display monitoring scripts on bigboard, olsrd's jsoninfo plugin must be enabled and configured.
