### PR TITLE
dnssd should not use plug as NonOlsrIf; it should only use one iface for...

### DIFF
--- a/default-files/etc/hotplug.d/iface/20-olsrd
+++ b/default-files/etc/hotplug.d/iface/20-olsrd
@@ -324,11 +324,9 @@ case "$(commotion state "$DEVICE" type)" in
             eval `ipcalc.sh "$(uci_get_state network "$INTERFACE" ipaddr)" "$(uci_get_state network "$INTERFACE" netmask)"`
             $DEBUG unset_olsrd_if $INTERFACE
             $DEBUG set_olsrd_hna4 $NETWORK $NETMASK $INTERFACE
-            $DEBUG set_olsrd_dnssd $INTERFACE
             ;;
           0)
             $DEBUG unset_olsrd_hna4 $INTERFACE
-            $DEBUG unset_olsrd_dnssd $INTERFACE
             $DEBUG set_olsrd_if $INTERFACE
             ;;
         esac
@@ -336,7 +334,6 @@ case "$(commotion state "$DEVICE" type)" in
       ifdown)
         $DEBUG unset_olsrd_if $INTERFACE
         $DEBUG unset_olsrd_hna4 $INTERFACE
-        $DEBUG unset_olsrd_dnssd $INTERFACE
       ;; 
     esac
 


### PR DESCRIPTION
... this option: ap or secAp.

This should fix the dnssd bug we saw at AMC, which causes massive instability with wireless ad-hoc links.

Test in conjunction with this: https://github.com/opentechinstitute/olsrd/pull/4

For testing, the nodes at LTS should be reflashed with this change, and tested in a configuration similar to AMC MagicNet, with both wired and wireless mesh links.

Preliminary testing indicates success in fixing this bug.
