### PR TITLE
Added hotplug script to match AP IP address to thisnode host alias

### DIFF
--- a/default-files/etc/hotplug.d/iface/90-thisnode
+++ b/default-files/etc/hotplug.d/iface/90-thisnode
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 #DEBUG="echo"
 
 if [ "$ACTION" == "ifup" ] && [ $(/usr/bin/commotion state "$DEVICE" mode) == "ap" ]; then


### PR DESCRIPTION
Closes Issue #34.

To test:
1. Delete 'thisnode' entry in /etc/hosts
2. /etc/init.d/network restart should add a 'thisnode' entry with the node access point's IP address.
3. In /etc/hosts, change the IP address for 'thisnode' to 192.168.1.20
4. /etc/init.d/network restart should update the 'thisnode' entry to the node access point's IP address.
