### PR TITLE
Thisnodefix

### DIFF
--- a/default-files/etc/hotplug.d/iface/90-thisnode
+++ b/default-files/etc/hotplug.d/iface/90-thisnode
@@ -14,14 +14,3 @@ if [ "$ACTION" == "ifup" ] && [ $(/usr/bin/commotion state "$DEVICE" mode) == "w
         fi                                                                                        
 fi
 
-if [ "$ACTION" == "ifup" ] && [ $(/usr/bin/commotion state "$DEVICE" mode) == "ap" ]; then
-	THISNODE=$(/usr/bin/commotion state "$DEVICE" ip)" thisnode"
-	if grep -Fq thisnode /etc/hosts; then
-		sed -ie "s/^.*thisnode$/$THISNODE/" /etc/hosts || \
-			logger -t commotion.hotplug.thisnode -s "Couldn't edit /etc/hosts"
-		logger -t commotion.hotplug.thisnode -s "Updating IP address for 'thisnode' host alias"
-	else
-		echo $THISNODE >> /etc/hosts
-		logger -t commotion.hotplug.thisnode -s "Creating entry for 'thisnode' host alias"
-	fi
-fi


### PR DESCRIPTION
Added a script to set the wired interface to use the "thisnode" alias before quickstart starts up. To avoid collision, I also removed the script to set the "thisnode" alias for the "ap" interface.

This can be tested by trying to reach "thisnode" while connected via ethernet (before running quickstart).

Optionally, you can test whether bridging works by trying to access "thisnode" while connected via the ap (after running quickstart).
