### PR TITLE
"Keep settings" works when flashing node

### DIFF
--- a/default-files/etc/sysupgrade.conf
+++ b/default-files/etc/sysupgrade.conf
@@ -1,0 +1,8 @@
+## This file contains files and directories that should
+## be preserved during an upgrade.
+
+/etc/commotion/
+/etc/nodogsplash/
+/etc/avahi/services/
+/etc/serval/serval.keyring
+/usr/lib/lua/luci/view/commotion-splash/splashtext.htm


### PR DESCRIPTION
fixes https://github.com/opentechinstitute/commotion-openwrt/issues/37

to test:
1) flash node
2) record SID from `servald id self`
3) add an application to the apps portal, with TTL > 1
4) make an edit to the splash text in Admin->Services->Captive Portal->Splash Text
5) use the web interface to flash, keeping the "Keep settings" box checked
6) upon reboot, ensure all wireless interfaces operate as they did before, with same SSID, keys, etc
7) ensure `servald id self` gives the same SID as before
8) make sure the node is a gateway and that the splash page text still has the edit you made
9) ensure the app you added is still listed in the apps portal
