### PR TITLE
Issue69

### DIFF
--- a/default-files/etc/hotplug.d/iface/90-thisnode
+++ b/default-files/etc/hotplug.d/iface/90-thisnode
@@ -29,6 +29,8 @@ if [ "$ACTION" == "ifup" ] && [ $(/usr/bin/commotion state "$DEVICE" mode) == "w
 		logger -t commotion.hotplug.thisnode -s "Setting '$ALIAS' ip address to $localip"
 		uci set network.$ALIAS.netmask=255.255.0.0
 		
+		#NOTE: this method of configuring aliases is deprecated in more recent versions of openwrt
+		
                                                                                      
 	kill -s HUP `pgrep dnsmasq`
 fi


### PR DESCRIPTION
NOTE: This pull request depends on https://github.com/opentechinstitute/commotiond/pull/57

The two can be tested in tandem

To test:

1) After flashing a node, and while connected via ethernet, go to the url "thisnode" in your browser (as you would normally). 
You should see the admin page.

2) On your machine:
$ host thisnode
You should see: 
thisnode.mesh.local has address 169.254.xx.xx

3) Back in your browser, run quickstart and ssh into the node (again, via ethernet)
$ uci show network

You should see an entry for the thisnode alias that looks like this:
network.thisnode=alias
network.thisnode.interface=plug
network.thisnode.ipaddr=169.254.7.130
network.thisnode.netmask=255.255.0.0
network.thisnode.proto=static

4) $ less /etc/config/network
You should NOT see an entry for the thisnode alias

5) Reboot the node. Recheck steps 1 through 4.

Store in a cool, dry place.
