### PR TITLE
Dashboard helper rewrite

### DIFF
--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # OpenWrt version: Attitude Adjustment (r36682)
-# Wed Dec 11 10:16:53 2013
+# Wed Dec 11 16:44:41 2013
 #
 CONFIG_HAVE_DOT_CONFIG=y
 # CONFIG_TARGET_ppc40x is not set
@@ -56,18 +56,6 @@ CONFIG_TARGET_ar71xx=y
 # CONFIG_TARGET_ubicom32 is not set
 # CONFIG_TARGET_uml is not set
 # CONFIG_TARGET_x86 is not set
-# CONFIG_TARGET_at91_9g20 is not set
-# CONFIG_TARGET_at91_9260 is not set
-# CONFIG_TARGET_at91_9263 is not set
-# CONFIG_TARGET_x86_generic is not set
-# CONFIG_TARGET_x86_olpc is not set
-# CONFIG_TARGET_x86_xen_domu is not set
-# CONFIG_TARGET_x86_ep80579 is not set
-# CONFIG_TARGET_x86_net5501 is not set
-# CONFIG_TARGET_x86_kvm_guest is not set
-# CONFIG_TARGET_x86_geos is not set
-# CONFIG_TARGET_x86_alix2 is not set
-# CONFIG_TARGET_x86_thincan is not set
 # CONFIG_TARGET_malta_le is not set
 # CONFIG_TARGET_malta_be is not set
 # CONFIG_TARGET_ixp4xx_generic is not set
@@ -100,36 +88,22 @@ CONFIG_TARGET_ar71xx_generic=y
 # CONFIG_TARGET_adm5120_router_le is not set
 # CONFIG_TARGET_adm5120_router_be is not set
 # CONFIG_TARGET_adm5120_rb1xx is not set
-# CONFIG_TARGET_mpc83xx_Default is not set
-# CONFIG_TARGET_mpc85xx_Default is not set
-# CONFIG_TARGET_at91_9g20_Default is not set
-# CONFIG_TARGET_at91_9260_flexibity-minimal is not set
-# CONFIG_TARGET_at91_9260_flexibity-xwrt is not set
-# CONFIG_TARGET_at91_9260_flexibity-luci is not set
-# CONFIG_TARGET_at91_9263_Default is not set
-# CONFIG_TARGET_ppc40x_Default is not set
-# CONFIG_TARGET_omap24xx_n810-base is not set
-# CONFIG_TARGET_omap24xx_n810-gui is not set
-# CONFIG_TARGET_ppc44x_Default is not set
-# CONFIG_TARGET_iop32x_Default is not set
-# CONFIG_TARGET_x86_generic_Generic is not set
-# CONFIG_TARGET_x86_generic_Soekris45xx is not set
-# CONFIG_TARGET_x86_generic_Soekris48xx is not set
-# CONFIG_TARGET_x86_generic_Wrap is not set
-# CONFIG_TARGET_x86_olpc_Default is not set
-# CONFIG_TARGET_x86_xen_domu_Default is not set
-# CONFIG_TARGET_x86_ep80579_Default is not set
-# CONFIG_TARGET_x86_net5501_Default is not set
-# CONFIG_TARGET_x86_kvm_guest_Default is not set
-# CONFIG_TARGET_x86_geos_Default is not set
-# CONFIG_TARGET_x86_alix2_Default is not set
-# CONFIG_TARGET_x86_thincan_DBE61 is not set
-# CONFIG_TARGET_octeon_generic is not set
-# CONFIG_TARGET_octeon_mototech is not set
+# CONFIG_TARGET_at91_9g20 is not set
+# CONFIG_TARGET_at91_9260 is not set
+# CONFIG_TARGET_at91_9263 is not set
+# CONFIG_TARGET_x86_generic is not set
+# CONFIG_TARGET_x86_olpc is not set
+# CONFIG_TARGET_x86_xen_domu is not set
+# CONFIG_TARGET_x86_ep80579 is not set
+# CONFIG_TARGET_x86_net5501 is not set
+# CONFIG_TARGET_x86_kvm_guest is not set
+# CONFIG_TARGET_x86_geos is not set
+# CONFIG_TARGET_x86_alix2 is not set
+# CONFIG_TARGET_x86_thincan is not set
 # CONFIG_TARGET_kirkwood_Default is not set
-# CONFIG_TARGET_leon_Default is not set
 # CONFIG_TARGET_pxcab_Default is not set
 # CONFIG_TARGET_uml_Default is not set
+# CONFIG_TARGET_leon_Default is not set
 # CONFIG_TARGET_malta_le_Default is not set
 # CONFIG_TARGET_malta_be_Default is not set
 # CONFIG_TARGET_goldfish_Default is not set
@@ -144,11 +118,11 @@ CONFIG_TARGET_ar71xx_generic=y
 # CONFIG_TARGET_cobalt_Default is not set
 # CONFIG_TARGET_ps3_petitboot_Default is not set
 # CONFIG_TARGET_atheros_Default is not set
+# CONFIG_TARGET_mpc52xx_Default is not set
 # CONFIG_TARGET_au1000_au1500_Atheros is not set
 # CONFIG_TARGET_au1000_au1500_InternetBox is not set
 # CONFIG_TARGET_au1000_au1500_MeshCube is not set
 # CONFIG_TARGET_au1000_au1550_DBAu1550 is not set
-# CONFIG_TARGET_mpc52xx_Default is not set
 # CONFIG_TARGET_mcs814x_Generic is not set
 # CONFIG_TARGET_mcs814x_dLAN_USB_Extender is not set
 # CONFIG_TARGET_rdc_ar525w is not set
@@ -164,7 +138,6 @@ CONFIG_TARGET_ar71xx_generic=y
 # CONFIG_TARGET_brcm63xx_GW6X00 is not set
 # CONFIG_TARGET_s3c24xx_openmoko_gta02_openmoko-gta02-minimal is not set
 # CONFIG_TARGET_s3c24xx_openmoko_gta02_openmoko-gta02-full is not set
-# CONFIG_TARGET_realview_Default is not set
 # CONFIG_TARGET_cns3xxx_Default is not set
 # CONFIG_TARGET_brcm47xx_Broadcom-b43 is not set
 # CONFIG_TARGET_brcm47xx_Broadcom-wl is not set
@@ -178,6 +151,7 @@ CONFIG_TARGET_ar71xx_generic=y
 # CONFIG_TARGET_brcm47xx_WL500GPv1 is not set
 # CONFIG_TARGET_brcm47xx_WRT350Nv1 is not set
 # CONFIG_TARGET_brcm47xx_WRTSL54GS is not set
+# CONFIG_TARGET_realview_Default is not set
 # CONFIG_TARGET_omap4_Default is not set
 # CONFIG_TARGET_ubicom32_Default is not set
 # CONFIG_TARGET_etrax_default is not set
@@ -342,9 +316,9 @@ CONFIG_TARGET_ar71xx_generic_UBNT=y
 # CONFIG_TARGET_avr32_Default is not set
 # CONFIG_TARGET_rb532_Default is not set
 # CONFIG_TARGET_sibyte_Default is not set
-# CONFIG_TARGET_imx21_Default is not set
 # CONFIG_TARGET_ep93xx_Default is not set
 # CONFIG_TARGET_ep93xx_Simone is not set
+# CONFIG_TARGET_imx21_Default is not set
 # CONFIG_TARGET_cns21xx_Default is not set
 # CONFIG_TARGET_gemini_Default is not set
 # CONFIG_TARGET_sparc_Default is not set
@@ -378,6 +352,32 @@ CONFIG_TARGET_ar71xx_generic_UBNT=y
 # CONFIG_TARGET_adm5120_router_be_P334WT is not set
 # CONFIG_TARGET_adm5120_router_be_P335WT is not set
 # CONFIG_TARGET_adm5120_rb1xx_RouterBoard is not set
+# CONFIG_TARGET_mpc83xx_Default is not set
+# CONFIG_TARGET_mpc85xx_Default is not set
+# CONFIG_TARGET_ppc40x_Default is not set
+# CONFIG_TARGET_at91_9g20_Default is not set
+# CONFIG_TARGET_at91_9260_flexibity-minimal is not set
+# CONFIG_TARGET_at91_9260_flexibity-xwrt is not set
+# CONFIG_TARGET_at91_9260_flexibity-luci is not set
+# CONFIG_TARGET_at91_9263_Default is not set
+# CONFIG_TARGET_omap24xx_n810-base is not set
+# CONFIG_TARGET_omap24xx_n810-gui is not set
+# CONFIG_TARGET_ppc44x_Default is not set
+# CONFIG_TARGET_iop32x_Default is not set
+# CONFIG_TARGET_x86_generic_Generic is not set
+# CONFIG_TARGET_x86_generic_Soekris45xx is not set
+# CONFIG_TARGET_x86_generic_Soekris48xx is not set
+# CONFIG_TARGET_x86_generic_Wrap is not set
+# CONFIG_TARGET_x86_olpc_Default is not set
+# CONFIG_TARGET_x86_xen_domu_Default is not set
+# CONFIG_TARGET_x86_ep80579_Default is not set
+# CONFIG_TARGET_x86_net5501_Default is not set
+# CONFIG_TARGET_x86_kvm_guest_Default is not set
+# CONFIG_TARGET_x86_geos_Default is not set
+# CONFIG_TARGET_x86_alix2_Default is not set
+# CONFIG_TARGET_x86_thincan_DBE61 is not set
+# CONFIG_TARGET_octeon_generic is not set
+# CONFIG_TARGET_octeon_mototech is not set
 CONFIG_HAS_SUBTARGETS=y
 CONFIG_TARGET_BOARD="ar71xx"
 CONFIG_TARGET_ARCH_PACKAGES="ar71xx"
@@ -2142,12 +2142,7 @@ CONFIG_PACKAGE_libcyassl=y
 # CONFIG_PACKAGE_libgnutls-extra is not set
 # CONFIG_PACKAGE_libgnutls-openssl is not set
 # CONFIG_PACKAGE_libmatrixssl is not set
-CONFIG_PACKAGE_libopenssl=y
-
-#
-# Configuration
-#
-# CONFIG_OPENSSL_ENGINE_CRYPTO is not set
+# CONFIG_PACKAGE_libopenssl is not set
 # CONFIG_PACKAGE_libpolarssl is not set
 
 #
@@ -2235,7 +2230,7 @@ CONFIG_PACKAGE_libblobmsg-json=y
 # CONFIG_PACKAGE_libcroco is not set
 # CONFIG_PACKAGE_libcryptoxx is not set
 # CONFIG_PACKAGE_libcunit is not set
-CONFIG_PACKAGE_libcurl=y
+# CONFIG_PACKAGE_libcurl is not set
 # CONFIG_PACKAGE_libcwiid is not set
 CONFIG_PACKAGE_libdaemon=y
 # CONFIG_PACKAGE_libdaq is not set
@@ -2485,7 +2480,7 @@ CONFIG_PACKAGE_nodogsplash=y
 # CONFIG_PACKAGE_atftpd is not set
 # CONFIG_PACKAGE_axel is not set
 # CONFIG_PACKAGE_cmdftp is not set
-CONFIG_PACKAGE_curl=y
+# CONFIG_PACKAGE_curl is not set
 # CONFIG_PACKAGE_lftp is not set
 # CONFIG_PACKAGE_ncftp is not set
 # CONFIG_PACKAGE_ncftp-utils is not set

--- a/feeds.conf
+++ b/feeds.conf
@@ -1,3 +1,3 @@
 src-svn packages svn://svn.openwrt.org/openwrt/branches/packages_12.09@36537
 src-svn luci http://svn.luci.subsignal.org/luci/tags/0.11.1/contrib/package
-src-git commotion git://github.com/opentechinstitute/commotion-feed.git;dashboard-helper-rewrite
+src-git commotion git://github.com/opentechinstitute/commotion-feed.git

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,7 @@ scripts/feeds update -a
 scripts/feeds install -a
 scripts/feeds uninstall olsrd libldns libcyassl
 # cyassl is an openwrt package, not feeds. Temporary solution:
+echo "Removing package/cyassl/ (cyassl-1.6.5)"
 rm -rf package/cyassl/
 scripts/feeds install -p commotion olsrd libldns libcyassl
 


### PR DESCRIPTION
To be tested in conjunction with opentechinstitute/commotion-dashboard-helper#10
- Updates openwrt config file to include httpclient and nixio-cyassl.
- Upgrades cyassl from version 1.6.5 to 2.8.0 (using makefile and patches from openwrt trunk -- https://dev.openwrt.org/browser/trunk/package/libs/cyassl revs 38609 and 38610, respectively)
- Removes curl, libcurl, and libopenssl

To test:
- Follow test procedures in opentechinstitute/commotion-dashboard-helper#10
