### PR TITLE
Disable default olsrd key, forces creation of new one

### DIFF
--- a/default-files/etc/hotplug.d/iface/20-olsrd
+++ b/default-files/etc/hotplug.d/iface/20-olsrd
@@ -282,7 +282,7 @@ set_olsrd_servald() {
 
   local name="$(add_olsrd_plugin "secure")"
 
-#  Setting default key
+#  Uncomment if you want to set the default olsrd key to something specific
 #  $DEBUG uci_set olsrd "$name" Keyfile "/etc/olsrd.d/olsrd_secure_key"
 
   return 0


### PR DESCRIPTION
This should satisfy https://github.com/opentechinstitute/commotion-feed/issues/16 and https://github.com/opentechinstitute/luci-commotion/issues/19, though we should still support a full range of serval keyring operations as in luci-commotion/issues/26.

To test on a node: `cd /etc/servald |serval id self` should give you something like `C6D124238A0F6E5BF6E674346DC798A2D840D78037AC79FF039C74E9446FD111`, which should be unique to each node.
