### PR TITLE
Set vi autoindent off by default

### DIFF
--- a/default-files/etc/profile
+++ b/default-files/etc/profile
@@ -1,0 +1,16 @@
+#!/bin/sh
+[ -f /etc/banner ] && cat /etc/banner
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+export HOME=$(grep -e "^${USER:-root}:" /etc/passwd | cut -d ":" -f 6)
+export HOME=${HOME:-/root}
+export PS1='\u@\h:\w\$ '
+export EXINIT='set noai' vi
+
+[ -x /bin/more ] || alias more=less
+[ -x /usr/bin/vim ] && alias vi=vim || alias vim=vi
+
+[ -z "$KSH_VERSION" -o \! -s /etc/mkshrc ] || . /etc/mkshrc
+
+[ -x /usr/bin/arp ] || arp() { cat /proc/net/arp; }
+[ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }


### PR DESCRIPTION
Will help prevent cascading indents when developing directly on router.

To test:
1. Copy a block of text with multiple indent levels (e.g., a few stanzas of /etc/config/network)
2. open a scratch file (e.g., `vi foo`) and paste. The text should appear properly formatted.
3. In the same file, in command mode (`<esc>`), type `:set ai`, then switch to insert and paste again. Each line of text should be indented one additional level.
