### PR TITLE
adding forwarding b/w mesh and lan zones

### DIFF
--- a/default-files/etc/config/firewall
+++ b/default-files/etc/config/firewall
@@ -54,6 +54,10 @@ config forwarding
 	option src 'lan'
 	option dest 'wan'
 
+config forwarding
+	option src 'mesh'
+	option dest 'lan'
+
 config rule
 	option src 'wan'
 	option dest_port '22'


### PR DESCRIPTION
in R1, routing from client to client on different nodes doesn't work. This should fix that.

to test:
1) flash on two nodes
2) connect one client to each node via ethernet, and make sure they can ping each other on their 10.x.x.x addresses
3) connect one client to each node via AP, and make sure they can ping each other

<!---
@huboard:{"order":8.0}
-->
