### PR TITLE
added patch to allow for longer iface names in netifd

### DIFF
--- a/patches/010-iface_name_len.patch
+++ b/patches/010-iface_name_len.patch
@@ -1,0 +1,20 @@
+--- a/interface.h
++++ b/interface.h
+@@ -17,6 +17,8 @@
+ #include "device.h"
+ #include "config.h"
+ 
++#define IFACE_LEN 256
++
+ struct interface;
+ struct interface_proto_state;
+ 
+@@ -86,7 +88,7 @@ struct interface {
+ 	struct list_head hotplug_list;
+ 	enum interface_event hotplug_ev;
+ 
+-	char name[IFNAMSIZ];
++	char name[IFACE_LEN];
+ 	const char *ifname;
+ 
+ 	bool available;

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,8 @@ scripts/feeds install -p commotion olsrd libldns libcyassl
 cp -v ../patches/910-fix-out-of-bounds-index.patch feeds/packages/utils/collectd/patches/
 cp -v ../patches/010-remove_exec.patch feeds/packages/net/netcat/patches/
 cp -v ../patches/010-initialize_vars_fix.patch feeds/packages/libs/avahi/patches/
+mkdir -p package/netifd/patches
+cp -v ../patches/010-iface_name_len.patch package/netifd/patches/
 cp -v ../config .config
 
 echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"


### PR DESCRIPTION
to test:

1) in `/etc/config/network`, change the line `config interface 'loopback'` to `config interface 'loopbackiswaytoolongblah'`
2) run `/etc/init.d/network restart`
3) running `ubus list`, you should see the line `network.interface.loopbackiswaytoolongblah`
