### PR TITLE
Changed default wired interface names to 'wan'

### DIFF
--- a/default-files/etc/config/firewall
+++ b/default-files/etc/config/firewall
@@ -25,7 +25,7 @@ config zone
 	option output 'ACCEPT'
 	option forward 'DROP'
 	option masq '1'
-	list network 'wired'
+	list network 'wan'
 
 config zone
 	option name 'vpn'

--- a/default-files/etc/config/network
+++ b/default-files/etc/config/network
@@ -10,7 +10,7 @@ config interface 'lan'
 	option class 'client'
 	option type 'bridge'
 
-config interface 'wired'
+config interface 'wan'
 	option ifname 'eth0'
 	option proto 'commotion'
 	option class 'wired'


### PR DESCRIPTION
This addresses #122, and should be used in concert with the equivalent pull request opentechinstitute/luci-commotion#205.

To test:
1. After flashing without retaining settings, make sure you can connect to the node via ethernet.
2. Run through setup_wizard. After it completes, make sure that the ethernet interface works as expected (gets a lease and/or gives out leases automatically).
3. Modify the settings under Additional Network Interfaces, and make sure that the settings that it's applying are used on the 'wan' config section and not 'wired.'
