### PR TITLE
extend uhttp script timeout from 60 to 300 seconds

### DIFF
--- a/default-files/etc/config/uhttpd
+++ b/default-files/etc/config/uhttpd
@@ -8,7 +8,7 @@ config uhttpd 'main'
 	option cert '/etc/uhttpd.crt'
 	option key '/etc/uhttpd.key'
 	option cgi_prefix '/cgi-bin'
-	option script_timeout '60'
+	option script_timeout '300'
 	option network_timeout '30'
 	option tcp_keepalive '1'
 


### PR DESCRIPTION
Many times on a poor quality wireless signal, or when upgrading a node over multiple hops, uHTTPd will give a timeout error when it takes more than 60 seconds to upload a firmware image. This will extend the timeout from 1 minute to 5 minutes.
