### PR TITLE
Add firewall.user include to default firewall configuration file.

### DIFF
--- a/default-files/etc/config/firewall
+++ b/default-files/etc/config/firewall
@@ -167,3 +167,6 @@ config rule
 	option src 'vpn'
 	option proto 'icmp'
 	option target 'ACCEPT'
+
+config include
+	option path /etc/firewall.user


### PR DESCRIPTION
Adds an option to the default firewall configuration file to allow for user-specified iptables rules in /etc/firewall.user. To test, make sure that the firewall still functions with this configuration change.
