### PR TITLE
Add OpenWRT repositories to local repositories.conf file to match remote one

### DIFF
--- a/repositories.conf.local.in
+++ b/repositories.conf.local.in
@@ -5,4 +5,11 @@
 ## This is the local package repository, do not remove!
 src ${COMMOTION_RELEASE} file://${CMAKE_CURRENT_BINARY_DIR}/bin/${TARGET}/${SUBTARGET}/packages/commotion
 src ${COMMOTION_RELEASE}-packages file://${CMAKE_CURRENT_BINARY_DIR}/bin/${TARGET}/${SUBTARGET}/packages/packages
+src/gz ${OPENWRT_RELEASE}_base http://downloads.openwrt.org/${OPENWRT_RELEASE}/${OPENWRT_VERSION}/${TARGET}/${SUBTARGET}/packages/base
+src/gz ${OPENWRT_RELEASE}_luci http://downloads.openwrt.org/${OPENWRT_RELEASE}/${OPENWRT_VERSION}/${TARGET}/${SUBTARGET}/packages/luci
+src/gz ${OPENWRT_RELEASE}_packages http://downloads.openwrt.org/${OPENWRT_RELEASE}/${OPENWRT_VERSION}/${TARGET}/${SUBTARGET}/packages/packages
+src/gz ${OPENWRT_RELEASE}_routing http://downloads.openwrt.org/${OPENWRT_RELEASE}/${OPENWRT_VERSION}/${TARGET}/${SUBTARGET}/packages/routing
+src/gz ${OPENWRT_RELEASE}_telephony http://downloads.openwrt.org/${OPENWRT_RELEASE}/${OPENWRT_VERSION}/${TARGET}/${SUBTARGET}/packages/telephony
+src/gz ${OPENWRT_RELEASE}_management http://downloads.openwrt.org/${OPENWRT_RELEASE}/${OPENWRT_VERSION}/${TARGET}/${SUBTARGET}/packages/management
+src/gz ${OPENWRT_RELEASE}_oldpackages http://downloads.openwrt.org/${OPENWRT_RELEASE}/${OPENWRT_VERSION}/${TARGET}/${SUBTARGET}/packages/oldpackages
 src imagebuilder file:packages


### PR DESCRIPTION
Previously, we only pulled in the upstream OpenWRT repositories for 'remote' builds, i.e. ones that pulled packages from repos anyway and didn't build any packages. However, in some cases there are bugfixes in core upstream packages that we miss out on (such as, in this case, a bugfix in px5g around generating unique serial numbers).

This adds the upstream package repositories to local builds as well. The disadvantage is that it precludes a completely offline build, however since we generally presuppose that we're building packages for a local build and those pull from online repositories, we maybe don't care so much at the moment.

Addresses #169 